### PR TITLE
[Blue] Database access

### DIFF
--- a/services/blue/src/api/DatabaseAccess/DbConnectionHolder.cs
+++ b/services/blue/src/api/DatabaseAccess/DbConnectionHolder.cs
@@ -15,7 +15,7 @@ namespace artiso.AdsdHotel.Blue.Api
             _connection = connection;
         }
 
-        public bool HasTransaction => !(_transaction is null);
+        public bool HasTransaction => _transaction is object;
 
         #region IDbConnection
 
@@ -39,7 +39,7 @@ namespace artiso.AdsdHotel.Blue.Api
 
         public IDbTransaction BeginTransaction()
         {
-            if (!(_transaction is null))
+            if (_transaction is object)
                 throw new InvalidOperationException("Can't create multiple transactions on this connection instance.");
 
             _transaction = _connection.BeginTransaction();
@@ -48,7 +48,7 @@ namespace artiso.AdsdHotel.Blue.Api
 
         public IDbTransaction BeginTransaction(IsolationLevel il)
         {
-            if (!(_transaction is null))
+            if (_transaction is object)
                 throw new InvalidOperationException("Can't create multiple transactions on this connection instance.");
 
             _transaction = _connection.BeginTransaction(il);

--- a/services/blue/src/api/DatabaseAccess/DbConnectionHolder.cs
+++ b/services/blue/src/api/DatabaseAccess/DbConnectionHolder.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+
+namespace artiso.AdsdHotel.Blue.Api
+{
+    internal interface IDbConnectionHolder : IDbConnection, IAsyncDisposable
+    {
+    }
+
+    internal class DbConnectionHolder : IDbConnectionHolder
+    {
+        private readonly IDbConnection _connection;
+
+        public DbConnectionHolder(IDbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        #region IDbConnection
+
+        string IDbConnection.ConnectionString
+        {
+            get => _connection.ConnectionString;
+            set => _connection.ConnectionString = value;
+        }
+
+        int IDbConnection.ConnectionTimeout => _connection.ConnectionTimeout;
+
+        string IDbConnection.Database => _connection.Database;
+
+        ConnectionState IDbConnection.State => _connection.State;
+
+        IDbTransaction IDbConnection.BeginTransaction() => _connection.BeginTransaction();
+
+        IDbTransaction IDbConnection.BeginTransaction(IsolationLevel il) => _connection.BeginTransaction(il);
+
+        void IDbConnection.ChangeDatabase(string databaseName) => _connection.ChangeDatabase(databaseName);
+
+        void IDbConnection.Close() => _connection.Close();
+
+        IDbCommand IDbConnection.CreateCommand() => _connection.CreateCommand();
+
+        void IDisposable.Dispose() => _connection.Dispose();
+
+        void IDbConnection.Open() => _connection.Open();
+
+        #endregion
+
+        #region IAsyncDisposable
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_connection is DbConnection dbConnection)
+            {
+                await dbConnection.DisposeAsync();
+            }
+            else
+            {
+                _connection.Dispose();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/services/blue/src/api/DatabaseAccess/DbConnectionHolder.cs
+++ b/services/blue/src/api/DatabaseAccess/DbConnectionHolder.cs
@@ -39,18 +39,20 @@ namespace artiso.AdsdHotel.Blue.Api
 
         public IDbTransaction BeginTransaction()
         {
-            if (_transaction is null)
-                _transaction = _connection.BeginTransaction();
+            if (!(_transaction is null))
+                throw new InvalidOperationException("Can't create multiple transactions on this connection instance.");
 
-            throw new InvalidOperationException("Can't create multiple transactions on this connection instance.");
+            _transaction = _connection.BeginTransaction();
+            return _transaction;
         }
 
         public IDbTransaction BeginTransaction(IsolationLevel il)
         {
-            if (_transaction is null)
-                _transaction = _connection.BeginTransaction(il);
+            if (!(_transaction is null))
+                throw new InvalidOperationException("Can't create multiple transactions on this connection instance.");
 
-            throw new InvalidOperationException("Can't create multiple transactions on this connection instance.");
+            _transaction = _connection.BeginTransaction(il);
+            return _transaction;
         }
 
         public IDbCommand CreateCommand()

--- a/services/blue/src/api/DatabaseAccess/IDbConnectionFactory.cs
+++ b/services/blue/src/api/DatabaseAccess/IDbConnectionFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace artiso.AdsdHotel.Blue.Api
+{
+    internal interface IDbConnectionFactory
+    {
+        Task<IDbConnectionHolder> CreateAsync(bool open = true);
+    }
+}

--- a/services/blue/src/api/DatabaseAccess/IDbConnectionFactory.cs
+++ b/services/blue/src/api/DatabaseAccess/IDbConnectionFactory.cs
@@ -4,6 +4,6 @@ namespace artiso.AdsdHotel.Blue.Api
 {
     internal interface IDbConnectionFactory
     {
-        Task<IDbConnectionHolder> CreateAsync(bool open = true);
+        Task<IDbConnectionHolder> CreateAsync();
     }
 }

--- a/services/blue/src/api/DatabaseAccess/IDbConnectionHolder.cs
+++ b/services/blue/src/api/DatabaseAccess/IDbConnectionHolder.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Data;
+
+namespace artiso.AdsdHotel.Blue.Api
+{
+    internal interface IDbConnectionHolder : IDbConnection, IAsyncDisposable
+    {
+        bool HasTransaction { get; }
+    }
+}

--- a/services/blue/src/api/DatabaseAccess/MySqlConnectionFactory.cs
+++ b/services/blue/src/api/DatabaseAccess/MySqlConnectionFactory.cs
@@ -13,13 +13,12 @@ namespace artiso.AdsdHotel.Blue.Api
             _connectionString = connectionString;
         }
 
-        public async Task<IDbConnectionHolder> CreateAsync(bool open)
+        public async Task<IDbConnectionHolder> CreateAsync()
         {
             var mySqlConnection = new MySqlConnection(_connectionString);
             var holder = new DbConnectionHolder(mySqlConnection);
 
-            if (open)
-                await holder.EnsureOpenAsync();
+            await holder.EnsureOpenAsync();
 
             return holder;
         }

--- a/services/blue/src/api/DatabaseAccess/MySqlConnectionFactory.cs
+++ b/services/blue/src/api/DatabaseAccess/MySqlConnectionFactory.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using RepoDb;
+
+namespace artiso.AdsdHotel.Blue.Api
+{
+    internal class MySqlConnectionFactory : IDbConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public MySqlConnectionFactory(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task<IDbConnectionHolder> CreateAsync(bool open)
+        {
+            var mySqlConnection = new MySqlConnection(_connectionString);
+            var holder = new DbConnectionHolder(mySqlConnection);
+
+            if (open)
+                await holder.EnsureOpenAsync();
+
+            return holder;
+        }
+    }
+}

--- a/services/blue/src/api/Handlers/ConfirmSelectedRoomTypeHandler.cs
+++ b/services/blue/src/api/Handlers/ConfirmSelectedRoomTypeHandler.cs
@@ -70,7 +70,7 @@ WHERE Id = @RoomTypeId AND Id NOT IN (
 
             var availableRoomType = queryResult.FirstOrDefault();
 
-            return !(availableRoomType is null);
+            return availableRoomType is object;
         }
 
         private async Task MarkPendingReservationAsConfirmed(

--- a/services/blue/src/api/Handlers/ConfirmSelectedRoomTypeHandler.cs
+++ b/services/blue/src/api/Handlers/ConfirmSelectedRoomTypeHandler.cs
@@ -4,85 +4,90 @@ using System.Linq;
 using System.Threading.Tasks;
 using artiso.AdsdHotel.Blue.Commands;
 using artiso.AdsdHotel.Blue.Contracts;
-using MySql.Data.MySqlClient;
 using NServiceBus;
 using RepoDb;
 
 namespace artiso.AdsdHotel.Blue.Api.Handlers
 {
-    class ConfirmSelectedRoomTypeHandler : IHandleMessages<ConfirmSelectedRoomType>
+    internal class ConfirmSelectedRoomTypeHandler : IHandleMessages<ConfirmSelectedRoomType>
     {
-        private MySqlConnection? _connection;
-        private IDbTransaction? _transaction;
+        private readonly IDbConnectionFactory _connectionFactory;
+
+        public ConfirmSelectedRoomTypeHandler(IDbConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
 
         public async Task Handle(ConfirmSelectedRoomType message, IMessageHandlerContext context)
         {
-            _connection = new MySqlConnection("Server=localhost;Port=13306;Database=adsd-blue;");
-            _transaction = _connection.EnsureOpen().BeginTransaction();
+            await using var connection = await _connectionFactory.CreateAsync();
+            using var transaction = connection.BeginTransaction();
 
-            using var connection = _connection;
-            using var transaction = _transaction;
-
-            var pendingReservation = await FindPendingReservationAsync(message.OrderId);
+            var pendingReservation = await FindPendingReservationAsync(connection, message.OrderId);
 
             if (pendingReservation is null)
                 // TODO: reply to caller with "fault" message.
                 throw new Exception($"Could not find pending reservation for {nameof(message.OrderId)} {message.OrderId}");
 
-            var valid = await IsPendingReservationValidAsync(pendingReservation);
+            var pendindReservationIsValid = await IsPendingReservationValidAsync(connection, pendingReservation);
 
-            if (!valid)
+            if (!pendindReservationIsValid)
                 // TODO: reply to caller with "fault" message.
                 throw new Exception("Pending reservation is not valid");
 
-            await CreateReservationAsync(pendingReservation);
+            await CreateReservationAsync(connection, pendingReservation);
 
-            await ConfirmPendingReservationAsync(pendingReservation.Id);
+            await MarkPendingReservationAsConfirmed(connection, pendingReservation.Id);
 
             transaction.Commit();
         }
 
-        private async Task<PendingReservation> FindPendingReservationAsync(string orderId)
+        private async Task<PendingReservation> FindPendingReservationAsync(
+            IDbConnection connection,
+            string orderId)
         {
             var query = @"
 SELECT * FROM PendingReservations
-WHERE OrderId = @OrderId;
-";
+WHERE OrderId = @OrderId;";
 
-            var queryResult = await _connection.ExecuteQueryAsync<PendingReservation>(query, new { orderId });
+            var queryResult = await connection.ExecuteQueryAsync<PendingReservation>(query, new { orderId });
 
             return queryResult.ToArray().FirstOrDefault();
         }
 
-        private async Task<bool> IsPendingReservationValidAsync(PendingReservation pendingReservation)
+        private async Task<bool> IsPendingReservationValidAsync(
+            IDbConnection connection,
+            PendingReservation pendingReservation)
         {
             var query = @"
 SELECT * FROM RoomTypes
 WHERE Id = @RoomTypeId AND Id NOT IN (
     SELECT DISTINCT RoomTypeId FROM Reservations
-    WHERE Start >= @Start AND Start <= @End
-);";
+    WHERE Start >= @Start AND Start <= @End);";
 
-            var queryResult = await _connection.ExecuteQueryAsync<RoomType>(query,
+            var queryResult = await connection.ExecuteQueryAsync<RoomType>(query,
                 new { pendingReservation.RoomTypeId, pendingReservation.Start, pendingReservation.End });
 
-            var availableRoomType = queryResult.ToArray().FirstOrDefault();
+            var availableRoomType = queryResult.FirstOrDefault();
 
-            return availableRoomType != null;
+            return !(availableRoomType is null);
         }
 
-        private async Task ConfirmPendingReservationAsync(string pendingReservationId)
+        private async Task MarkPendingReservationAsConfirmed(
+            IDbConnection connection,
+            string pendingReservationId)
         {
             var query = @"
 UPDATE PendingReservations
 SET Confirmed = True
-WHERE PendingReservationId = @PendingReservationId;
-";
+WHERE PendingReservationId = @pendingReservationId;";
 
-            await _connection.ExecuteNonQueryAsync(query, new { PendingReservationId = pendingReservationId }, transaction: _transaction);
+            await connection.ExecuteNonQueryAsync(query, new { pendingReservationId });
         }
 
-        private async Task<Reservation> CreateReservationAsync(PendingReservation pendingReservation)
+        private async Task<Reservation> CreateReservationAsync(
+            IDbConnection connection,
+            PendingReservation pendingReservation)
         {
             var reservationId = Guid.NewGuid().ToString();
 
@@ -94,7 +99,7 @@ WHERE PendingReservationId = @PendingReservationId;
                 pendingReservation.End,
                 DateTime.UtcNow);
 
-            await _connection.InsertAsync(DatabaseTableNames.Reservations, reservation, transaction: _transaction);
+            await connection.InsertAsync(DatabaseTableNames.Reservations, reservation);
 
             return reservation;
         }

--- a/services/blue/src/api/Handlers/ConfirmSelectedRoomTypeHandler.cs
+++ b/services/blue/src/api/Handlers/ConfirmSelectedRoomTypeHandler.cs
@@ -48,7 +48,7 @@ namespace artiso.AdsdHotel.Blue.Api.Handlers
         {
             var query = @"
 SELECT * FROM PendingReservations
-WHERE OrderId = @OrderId;";
+WHERE OrderId = @orderId;";
 
             var queryResult = await connection.ExecuteQueryAsync<PendingReservation>(query, new { orderId });
 

--- a/services/blue/src/api/Handlers/RoomTypeSelectionHandler.cs
+++ b/services/blue/src/api/Handlers/RoomTypeSelectionHandler.cs
@@ -3,46 +3,54 @@ using System.Linq;
 using System.Threading.Tasks;
 using artiso.AdsdHotel.Blue.Commands;
 using artiso.AdsdHotel.Blue.Contracts;
-using MySql.Data.MySqlClient;
 using NServiceBus;
 using RepoDb;
 
 namespace artiso.AdsdHotel.Blue.Api
 {
-    public class RoomTypeSelectionHandler : IHandleMessages<SelectRoomType>
+    internal class RoomTypeSelectionHandler : IHandleMessages<SelectRoomType>
     {
+        private readonly IDbConnectionFactory _connectionFactory;
+
+        public RoomTypeSelectionHandler(IDbConnectionFactory connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+        }
+
         public async Task Handle(SelectRoomType message, IMessageHandlerContext context)
         {
-            using (var connection = new MySqlConnection("Server=localhost;Port=13306;Database=adsd-blue;"))
-            {
-                var query = @"
+            await using var connection = await _connectionFactory.CreateAsync();
+
+            var query = @"
 SELECT * FROM RoomTypes
 WHERE Id = @RoomTypeId AND Id NOT IN (
     SELECT DISTINCT RoomTypeId FROM Reservations
-    WHERE Start >= @Start AND Start <= @End
-);";
+    WHERE Start >= @Start AND Start <= @End);";
 
-                var queryResult = await connection.ExecuteQueryAsync<RoomType>(query,
-                    new { message.RoomTypeId, message.Start, message.End });
+            var queryResult = await connection.ExecuteQueryAsync<RoomType>(query, new
+            {
+                message.RoomTypeId,
+                message.Start,
+                message.End
+            });
 
-                var availableRoomType = queryResult.ToArray().FirstOrDefault();
+            var availableRoomType = queryResult.FirstOrDefault();
 
-                if (availableRoomType is null)
-                    // TODO: reply to caller with "fault" message.
-                    throw new Exception(
-                        $"Room type '{message.RoomTypeId}' is not available " +
-                        $"anymore on the given period: {message.Start} - {message.End}");
+            if (availableRoomType is null)
+                // TODO: reply to caller with "fault" message.
+                throw new Exception(
+                    $"Room type '{message.RoomTypeId}' is not available " +
+                    $"anymore on the given period: {message.Start} - {message.End}");
 
-                var pendingReservation = new PendingReservation(
-                    Guid.NewGuid().ToString(),
-                    message.OrderId,
-                    message.RoomTypeId,
-                    message.Start,
-                    message.End,
-                    DateTime.UtcNow);
+            var pendingReservation = new PendingReservation(
+                Guid.NewGuid().ToString(),
+                message.OrderId,
+                message.RoomTypeId,
+                message.Start,
+                message.End,
+                DateTime.UtcNow);
 
-                await connection.InsertAsync(DatabaseTableNames.PendingReservation, pendingReservation);
-            }
+            await connection.InsertAsync(DatabaseTableNames.PendingReservation, pendingReservation);
         }
     }
 }

--- a/services/blue/src/api/Internals/DatabaseTableNames.cs
+++ b/services/blue/src/api/Internals/DatabaseTableNames.cs
@@ -1,8 +1,8 @@
-﻿namespace artiso.AdsdHotel.Blue.Api
+﻿
+namespace artiso.AdsdHotel.Blue.Api
 {
     internal class DatabaseTableNames
     {
-
         public const string Reservations = "Reservations";
 
         public const string PendingReservation = "PendingReservations";

--- a/services/blue/src/contracts/BedType.cs
+++ b/services/blue/src/contracts/BedType.cs
@@ -2,7 +2,7 @@
 {
     public class BedType
     {
-        internal BedType(string id, string name, int width, int length)
+        internal BedType(string id, string name, double width, double length)
         {
             Id = id;
             Name = name;
@@ -14,8 +14,8 @@
 
         public string Name { get; }
 
-        public int Width { get; }
+        public double Width { get; }
 
-        public int Length { get; }
+        public double Length { get; }
     }
 }

--- a/services/blue/tye.yaml
+++ b/services/blue/tye.yaml
@@ -13,7 +13,11 @@ services:
     image: mysql
     bindings:
       - name: mysql
-        port: 13306
+        port: 3306
+        containerPort: 3306
+    env:
+      - name: MYSQL_ALLOW_EMPTY_PASSWORD
+        value: true
   - name: rabbit
     image: rabbitmq:management-alpine
     bindings:


### PR DESCRIPTION
Adds:
- `IDbConnectionFactory`
- `MySqlConnectionFactory`
- `IDbConnectionHolder`
  |> an enhanced `IDbConnection` that is transaction-aware and supports `IAsyncDisposable`

### Rationale

RepoDb provides extension methods on the `IDbConnection` type (defined in `System.Data.Common`):
```csharp
ExecuteQueryAsync<TResult>(this IDbConnection connection, ...
``` 
Instead of accepting a concrete connection type, **1. Accept an `IDbConnection`**, which also allows for testability.

In order to better handle the lifecycle of the connection **2. Define a connection factory**.

The connection will [probably](https://dev.mysql.com/doc/dev/connector-net/8.0/html/T_MySql_Data_MySqlClient_MySqlConnection.htm) inherit from `DbConnection` (abstract class, also defined in `System.Data.Common`). This type [implements](https://source.dot.net/#System.Data.Common/System/Data/Common/DbConnection.cs,5f329ec84852e62f) `IAsyncDisposable`, while the interface doesn't.
In order to allow for testability _and_ features access, **3. Define a custom connection interface to bridge the gap**: `IDbConnectionHolder`.

RepoDb expects to get any transaction as a parameter: given though that it relies on `IDbConnection`, `IDbTransaction` and `IDbCommand`, **4. Enhance `IDbConnectionHolder` to auto-set the opened transaction on any new `IDbCommand`**.
The drawback: only a single transaction can be opened on an instance of `IDbConnectionHolder`. 