### PR TITLE
Enforce net5.0

### DIFF
--- a/services/Directory.Build.props
+++ b/services/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/services/Directory.Build.props
+++ b/services/Directory.Build.props
@@ -4,13 +4,13 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-	<PropertyGroup>
-		<Authors>artiso solutions GmbH</Authors>
-	</PropertyGroup>
-	<PropertyGroup>
-		<Nuget-NServiceBus-Version>7.4.4</Nuget-NServiceBus-Version>
-		<Nuget-NServiceBus-NewtonSoft-Version>2.2.0</Nuget-NServiceBus-NewtonSoft-Version>
-		<Nuget-NServiceBus-RabbitMQ-Version>6.0.0</Nuget-NServiceBus-RabbitMQ-Version>
-		<Nuget-NServiceBus-Callbacks-Version>3.0.0</Nuget-NServiceBus-Callbacks-Version>
-	</PropertyGroup>
+  <PropertyGroup>
+    <Authors>artiso solutions GmbH</Authors>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Nuget-NServiceBus-Version>7.4.4</Nuget-NServiceBus-Version>
+    <Nuget-NServiceBus-NewtonSoft-Version>2.2.0</Nuget-NServiceBus-NewtonSoft-Version>
+    <Nuget-NServiceBus-RabbitMQ-Version>6.0.0</Nuget-NServiceBus-RabbitMQ-Version>
+    <Nuget-NServiceBus-Callbacks-Version>3.0.0</Nuget-NServiceBus-Callbacks-Version>
+  </PropertyGroup>
 </Project>

--- a/services/blue/src/ambassador/artiso.AdsdHotel.Blue.Ambassador.csproj
+++ b/services/blue/src/ambassador/artiso.AdsdHotel.Blue.Ambassador.csproj
@@ -1,7 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
 </Project>

--- a/services/blue/src/api/artiso.AdsdHotel.Blue.Api.csproj
+++ b/services/blue/src/api/artiso.AdsdHotel.Blue.Api.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/services/blue/src/commands/artiso.AdsdHotel.Blue.Commands.csproj
+++ b/services/blue/src/commands/artiso.AdsdHotel.Blue.Commands.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\contracts\artiso.AdsdHotel.Blue.Contracts.csproj" />
   </ItemGroup>

--- a/services/blue/src/contracts/artiso.AdsdHotel.Blue.Contracts.csproj
+++ b/services/blue/src/contracts/artiso.AdsdHotel.Blue.Contracts.csproj
@@ -1,7 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
 </Project>

--- a/services/blue/src/events/artiso.AdsdHotel.Blue.Events.csproj
+++ b/services/blue/src/events/artiso.AdsdHotel.Blue.Events.csproj
@@ -1,7 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
Enforces net5.0 following the [meeting decision](https://github.com/artiso-solutions/adsd-hotel/wiki/Meeting-notes#net5).
The following is not required to be specified anymore in `.csproj` files:
```xml
<PropertyGroup>
  <TargetFramework>net5.0</TargetFramework>
</PropertyGroup>
```